### PR TITLE
Add default .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+fly.toml
+.git/
+target/


### PR DESCRIPTION
When cloning and then launching with `fly launch`, often times when any Rust language server is installed, the language server  creates a `target/debug/*` folder with a huge amount of files. Docker does not ignore the `target/` directory and will try to push all of the debug files to the remote builder. This causes extreme delays and possibly crashes on slow networks.

Closes #2